### PR TITLE
fix: properly export type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "files": [
     "dist"
   ],
-  "main": "dist/ui.umd.cjs",
-  "module": "dist/ui.js",
-  "types": "dist/main.d.ts",
+  "main": "./dist/ui.umd.cjs",
+  "module": "./dist/ui.js",
+  "types": "./dist/main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/main.d.ts",
       "import": "./dist/ui.js",
       "require": "./dist/ui.umd.cjs"
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "license": "MIT",
   "homepage": "https://tietokilta.github.io/ui/",
+  "author": "Mikael Siidorow <mikael@siidorow.com> (https://siidorow.com)",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
The project wasn't properly exporting type definitions as found out by https://arethetypeswrong.github.io/.

There's still some funky issue with CJS exports, but that's probably difficult to fix if the vite dts plugin doesn't support cjs.